### PR TITLE
Use JSZip correctly

### DIFF
--- a/src/archive.js
+++ b/src/archive.js
@@ -2,9 +2,7 @@ import {defer, isXml, parse} from "./utils/core";
 import request from "./utils/request";
 import mime from "./utils/mime";
 import Path from "./utils/path";
-//lingVis: import from this separate script does not work in Android WebView for some reason,
-// so we just use window.JSZip
-//import JSZip from "jszip/dist/jszip";
+import JSZip from "jszip";
 
 /**
  * Handles Unzipping a requesting files from an Epub Archive

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,6 @@ module.exports = {
 		minimize: MINIMIZE
 	},
 	externals: {
-		"jszip/dist/jszip": "JSZip",
 		"xmldom": "xmldom"
 	},
 	plugins: [],


### PR DESCRIPTION
import JSZip from dependcy https://github.com/gmick919/epub.js/blob/f4066af493abbc789896133fc73907f16d611e8d/package.json#L62
Also using jszip as shown in example from cdn is not necessary now. (It's probably outdated examples)