### PR TITLE
Fix previous style in rendition.themes.select()

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -133,6 +133,10 @@ class Themes {
 
 		contents = this.rendition.getContents();
 		contents.forEach( (content) => {
+			let previousStyleSheet = content._getStylesheetNode(prev);
+			if (previousStyleSheet) {
+				previousStyleSheet.remove();
+			}
 			content.removeClass(prev);
 			content.addClass(name);
 		});


### PR DESCRIPTION
Previous styles are not removed after rendition.themes.select() and it causes a incorrect behaviour.
This is related to issue https://github.com/futurepress/epub.js/issues/1208
And it's duplication of this closed issue https://github.com/futurepress/epub.js/pull/1267